### PR TITLE
Add web search API integration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,5 +1,6 @@
 # OpenAI API Key
 OPENAI_API_KEY=your_openai_api_key_here
+SERPAPI_KEY=your_serpapi_key_here
 
 # Supabase Configuration
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url_here

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A web-based tool that allows users to visually map their workflows and receive A
 - **AI Opportunities Identification**: Get AI-powered automation suggestions based on your workflow
 - **Implementation Guidance**: Receive detailed guidance on how to implement identified automation opportunities
 - **Organization-based Isolation**: Share workflows with members of your organization
+- **Web Search Integration**: Retrieve real-world AI examples using SerpAPI
 
 ## Tech Stack
 
@@ -15,6 +16,7 @@ A web-based tool that allows users to visually map their workflows and receive A
 - **Data Visualization**: React Flow
 - **Authentication & Database**: Supabase (Auth, PostgreSQL)
 - **AI Integration**: OpenAI GPT-4.1
+- **Web Search**: SerpAPI for external examples
 
 ## Setup Instructions
 
@@ -23,6 +25,7 @@ A web-based tool that allows users to visually map their workflows and receive A
 - Node.js 18+ and npm
 - Supabase account (for database and authentication)
 - OpenAI API key
+- SerpAPI key for web search
 
 ### Installation
 
@@ -49,6 +52,7 @@ A web-based tool that allows users to visually map their workflows and receive A
    Edit `.env.local` and fill in the credentials you just copied:
    ```
    OPENAI_API_KEY=your_openai_api_key
+   SERPAPI_KEY=your_serpapi_key
    NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
    NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
    SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,34 @@
+export type SearchResult = {
+  title: string;
+  link: string;
+  snippet: string;
+};
+
+export async function webSearch(query: string, numResults = 5): Promise<SearchResult[]> {
+  if (!process.env.SERPAPI_KEY) {
+    throw new Error('SERPAPI_KEY is not defined in environment variables');
+  }
+
+  const params = new URLSearchParams({
+    q: query,
+    api_key: process.env.SERPAPI_KEY,
+    num: String(numResults),
+  });
+
+  const response = await fetch(`https://serpapi.com/search.json?${params.toString()}`);
+
+  if (!response.ok) {
+    throw new Error(`Search API request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+
+  // Extract organic search results if available
+  const results = (data.organic_results || []).slice(0, numResults).map((item: any) => ({
+    title: item.title,
+    link: item.link,
+    snippet: item.snippet,
+  }));
+
+  return results as SearchResult[];
+}

--- a/src/pages/api/webSearch.ts
+++ b/src/pages/api/webSearch.ts
@@ -1,0 +1,25 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { webSearch, SearchResult } from '@/lib/search';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ results: SearchResult[] } | { error: string }>
+) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const query = Array.isArray(req.query.q) ? req.query.q[0] : req.query.q;
+
+  if (!query) {
+    return res.status(400).json({ error: 'Missing search query' });
+  }
+
+  try {
+    const results = await webSearch(query as string);
+    return res.status(200).json({ results });
+  } catch (error: any) {
+    console.error('Search API error:', error);
+    return res.status(500).json({ error: 'Failed to perform search' });
+  }
+}


### PR DESCRIPTION
## Summary
- integrate SerpAPI based web search
- expose new `/api/webSearch` endpoint
- document SerpAPI key in README and env example
- note search ability in features and tech stack

## Testing
- `npm run lint` *(fails: next not found)*